### PR TITLE
fix: theme drawer fonts

### DIFF
--- a/components/Palette.tsx
+++ b/components/Palette.tsx
@@ -35,11 +35,11 @@ export function Palette() {
   } = useThemeContext()
 
   return (
-    <div className="space-y-6 font-['Satoshi']">
+    <div className="space-y-6 font-satoshi">
       {/* Background */}
       <div className="flex flex-col gap-y-4 py-4 px-6 rounded-xl shadow-[0_1px_2px_1px_rgba(0,0,0,0.12)]">
         {/* Image upload */}
-        {/* <div className="flex justify-between items-center gap-x-32">
+        {/* <div className="flex items-center justify-between gap-x-32">
           <span>Upload image</span>
           <label className="image-picker">
             Upload File
@@ -51,8 +51,8 @@ export function Palette() {
             />
           </label>
         </div> */}
-        <span className="uppercase font-semibold">Background</span>
-        <div className="flex justify-between items-center gap-x-32">
+        <span className="font-semibold uppercase">Background</span>
+        <div className="flex items-center justify-between gap-x-32">
           <label>Color</label>
           <input
             id="backgroundColor"
@@ -65,8 +65,8 @@ export function Palette() {
       </div>
       {/* Colors */}
       <div className="flex flex-col gap-y-4 py-4 px-6 rounded-xl shadow-[0_1px_2px_1px_rgba(0,0,0,0.12)]">
-        <span className="uppercase font-semibold">Colors</span>
-        <div className="flex justify-between items-center gap-x-4">
+        <span className="font-semibold uppercase">Colors</span>
+        <div className="flex items-center justify-between gap-x-4">
           <label>Primary</label>
           <input
             id="text"
@@ -76,7 +76,7 @@ export function Palette() {
             onChange={(e) => setPrimary(e.target.value)}
           />
         </div>
-        <div className="flex justify-between items-center gap-x-4">
+        <div className="flex items-center justify-between gap-x-4">
           <label>Secondary</label>
           <input
             id="secondary"
@@ -86,7 +86,7 @@ export function Palette() {
             onChange={(e) => setSecondary(e.target.value)}
           />
         </div>
-        <div className="flex justify-between items-center gap-x-4">
+        <div className="flex items-center justify-between gap-x-4">
           <label>Tertiary</label>
           <input
             id="tertiary"
@@ -96,7 +96,7 @@ export function Palette() {
             onChange={(e) => setTertiary(e.target.value)}
           />
         </div>
-        <div className="flex justify-between items-center gap-x-4">
+        <div className="flex items-center justify-between gap-x-4">
           <label>Highlight</label>
           <input
             id="highlight"
@@ -109,8 +109,8 @@ export function Palette() {
       </div>
       {/* Fonts */}
       <div className="flex flex-col gap-y-4 py-4 px-6 rounded-xl shadow-[0_1px_2px_1px_rgba(0,0,0,0.12)]">
-        <span className="uppercase font-semibold">Fonts</span>
-        <div className="flex justify-between items-center gap-x-4">
+        <span className="font-semibold uppercase">Fonts</span>
+        <div className="flex items-center justify-between gap-x-4">
           <span>Headline</span>
           <div>
             <select
@@ -197,7 +197,7 @@ export function Palette() {
           </Slider.Root>
         </div>
         <br></br>
-        <div className="flex justify-between items-center gap-x-4">
+        <div className="flex items-center justify-between gap-x-4">
           <span>Body</span>
           <div>
             <select
@@ -261,7 +261,7 @@ export function Palette() {
             </select>
           </div>
         </div>
-        <div className="flex justify-between items-center gap-x-4">
+        <div className="flex items-center justify-between gap-x-4">
           <span>Caption</span>
           <div>
             <select
@@ -328,8 +328,8 @@ export function Palette() {
       </div>
       {/* Dropshadow */}
       <div className="flex flex-col gap-y-4 py-4 px-6 rounded-xl shadow-[0_1px_2px_1px_rgba(0,0,0,0.12)]">
-        <span className="uppercase font-semibold">Dropshadow</span>
-        <div className="flex justify-between items-center gap-x-32">
+        <span className="font-semibold uppercase">Dropshadow</span>
+        <div className="flex items-center justify-between gap-x-32">
           <label>Color</label>
           <input
             id="shadowColor"
@@ -339,7 +339,7 @@ export function Palette() {
             onChange={(e) => setShadowColor(e.target.value)}
           />
         </div>
-        <div className="flex justify-between items-center gap-x-32">
+        <div className="flex items-center justify-between gap-x-32">
           <label>Spread</label>
           <div className="flex justify-end">
             <Slider.Root
@@ -367,8 +367,8 @@ export function Palette() {
       </div>
       {/* Corner radius */}
       <div className="flex flex-col gap-y-4 py-4 px-6 rounded-xl shadow-[0_1px_2px_1px_rgba(0,0,0,0.12)]">
-        <span className="uppercase font-semibold">Corner Radius</span>
-        <div className="flex justify-between items-center gap-x-32">
+        <span className="font-semibold uppercase">Corner Radius</span>
+        <div className="flex items-center justify-between gap-x-32">
           <label>Objects</label>
           <div className="flex justify-end">
             <Slider.Root
@@ -392,7 +392,7 @@ export function Palette() {
             </Slider.Root>
           </div>
         </div>
-        <div className="flex justify-between items-center gap-x-32 mt-6">
+        <div className="flex items-center justify-between mt-6 gap-x-32">
           <label>Buttons</label>
           <div className="flex justify-end">
             <Slider.Root

--- a/components/drawer/DrawerComposition.tsx
+++ b/components/drawer/DrawerComposition.tsx
@@ -43,8 +43,8 @@ export function DrawerComposition({
                   overflowY: "scroll",
                 }}
               >
-                <div className="flex justify-between items-center p-6">
-                  <span className="text-[1.5rem] font-medium leading-10 tracking-[-0.5px] text-[#121212] font-['Satoshi']">
+                <div className="flex items-center justify-between p-6">
+                  <span className="text-[1.5rem] font-medium leading-10 tracking-[-0.5px] text-[#121212] font-satoshi">
                     Theme Editor
                   </span>
                   <button onClick={requestClose}>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -50,7 +50,7 @@
 }
 
 .bg-tertiary {
-  background-color: var(--color-tertiary)
+  background-color: var(--color-tertiary);
 }
 
 .bg-highlight {
@@ -76,7 +76,7 @@
 .headline {
   font-family: var(--headline);
   font-size: var(--headline-size, 24px);
-  line-height: 166.67%;;
+  line-height: 166.67%;
 }
 
 .body {
@@ -96,7 +96,8 @@
 }
 
 .custom-shadow {
-  box-shadow: var(--shadow-spread) calc(var(--shadow-spread) * 2) calc(var(--shadow-spread) * 4) 0 var(--color-shadow);
+  box-shadow: var(--shadow-spread) calc(var(--shadow-spread) * 2)
+    calc(var(--shadow-spread) * 4) 0 var(--color-shadow);
 }
 
 * {
@@ -134,6 +135,8 @@ a {
 }
 
 .color-picker {
+  -webkit-appearance: none;
+  -moz-appearance: none;
   appearance: none;
   --webkit-appearance: none;
   --moz-appearance: none;
@@ -197,8 +200,8 @@ div[data-radix-popper-content-wrapper] {
 }
 
 .new-line {
-  white-space:pre
- }
+  white-space: pre;
+}
 
 /* On screens that are 768px or less, create sheet for dropdown */
 @media screen and (max-width: 768px) {
@@ -231,11 +234,11 @@ div[data-radix-popper-content-wrapper] {
 
 /* Handle */
 ::-webkit-scrollbar-thumb {
-  background: var(--tertiary);
+  background: var(--color-tertiary);
   border-radius: 48px;
 }
 
 /* Handle on hover */
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--tertiary);
+  background: var(--color-tertiary);
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,15 +1,20 @@
-const { fontFamily } = require("tailwindcss/defaultTheme")
+const defaultTheme = require("tailwindcss/defaultTheme")
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+   future: {
+    hoverOnlyWhenSupported: true,
+  },
   darkMode: ["class", '[data-theme="dark"]'],
   theme: {
     extend: {
       // Allows the use of the font-sans, font-body, font-caption utility class to apply the font to any element
       fontFamily: {
-        sans: ["var(--headline)", "var(--font-satoshi)", ...fontFamily.sans],
-        body: ["var(--body)", "var(--font-space-mono)", ...fontFamily.sans],
-        caption: ["var(--caption)", ...fontFamily.mono],
+        sans: ["var(--headline)", "var(--font-satoshi)", ...defaultTheme.fontFamily.sans],
+        body: ["var(--body)", "var(--font-space-mono)", ...defaultTheme.fontFamily.sans],
+        caption: ["var(--caption)", ...defaultTheme.fontFamily.mono],
+        satoshi: ["var(--font-satoshi)", ...defaultTheme.fontFamily.sans],
+        headline: ["var(--headline)", ...defaultTheme.fontFamily.sans],
       },
       colors: {
         current: "currentColor",


### PR DESCRIPTION
Saw the drawer not using the satoshi font default. Switched  `font-['Satoshi']` with `font-satoshi`. Also fixed the scrollbar color it was referencing and old css var.

And added the experimental hover support to the tailwind config. 

So hover styles only show if the device supports it. It'll be default in tailwind v4. 