### PR TITLE
fix: retrieve correct timestamp ref for auction ended

### DIFF
--- a/components/BlurImage.tsx
+++ b/components/BlurImage.tsx
@@ -16,6 +16,7 @@ export const BlurImage = (props: ImageProps) => {
       )}
     >
       <NextImage
+        priority
         {...props}
         className={cn(
           'duration-700 ease-in-out',

--- a/components/auction/Auction.tsx
+++ b/components/auction/Auction.tsx
@@ -36,6 +36,8 @@ const Auction = () => {
     isLastToken,
   } = useTokenExplorer()
 
+  console.log('current: ', currentTokenId)
+
   const { tokenName, tokenThumbnail } = useTokenMetadata(
     currentTokenId.toString()
   )

--- a/components/auction/Auction.tsx
+++ b/components/auction/Auction.tsx
@@ -36,8 +36,6 @@ const Auction = () => {
     isLastToken,
   } = useTokenExplorer()
 
-  console.log('current: ', currentTokenId)
-
   const { tokenName, tokenThumbnail } = useTokenMetadata(
     currentTokenId.toString()
   )

--- a/components/auction/AuctionSheet.tsx
+++ b/components/auction/AuctionSheet.tsx
@@ -52,6 +52,7 @@ export function AuctionSheet({
   const { isMobile } = useIsMobile()
 
   const [open, setOpen] = useState<boolean | undefined>()
+  const [timestamp, setTimestamp] = useState<number | undefined>()
 
   const { isConnected } = useAuth()
 
@@ -74,6 +75,21 @@ export function AuctionSheet({
     event.preventDefault()
     createBid()
   }
+
+  useEffect(() => {
+    if (tokenData) {
+      const provider = new ethers.providers.JsonRpcProvider(
+        `https://eth-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_KEY}`
+      )
+
+      const blockNumber = tokenData.mintInfo.mintContext.blockNumber
+
+      provider.getBlock(blockNumber).then((block) => {
+        setTimestamp(block.timestamp)
+      })
+    }
+    return
+  }, [tokenData])
 
   const externalLinkBaseURI = 'https://nouns.build/dao'
 
@@ -168,17 +184,18 @@ export function AuctionSheet({
                     {/* Auction ended */}
                     <Stack>
                       <Caption>
-                        <span className="uppercase">
-                          {tokenData?.mintInfo
-                            ? `${format(
-                                fromUnixTime(
-                                  tokenData?.mintInfo.mintContext
-                                    .blockNumber as number
-                                ),
-                                'MMMM d, yyyy'
-                              )}`
-                            : 'N/A'}
-                        </span>
+                        {timestamp ? (
+                          <span className="uppercase">
+                            {tokenData?.mintInfo
+                              ? `${format(
+                                  fromUnixTime(timestamp),
+                                  'MMMM d, yyyy'
+                                )}`
+                              : 'N/A'}
+                          </span>
+                        ) : (
+                          <span className="uppercase">Loading...</span>
+                        )}
                       </Caption>
                       <BodySmall className="text-tertiary">
                         Auction ended

--- a/components/auction/AuctionSheet.tsx
+++ b/components/auction/AuctionSheet.tsx
@@ -19,6 +19,7 @@ import { useAuth } from '@/hooks/useAuth'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { ENV } from '@/utils/env'
 import { useActiveAuction, useDaoTokenQuery } from '@public-assembly/dao-utils'
+import { ALCHEMY_RPC_URL } from 'constants/rpcEndpoint'
 import { format, fromUnixTime } from 'date-fns'
 import { BigNumber, ethers } from 'ethers'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -79,17 +80,18 @@ export function AuctionSheet({
   useEffect(() => {
     if (tokenData) {
       const provider = new ethers.providers.JsonRpcProvider(
-        `https://eth-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_KEY}`
+        `${ALCHEMY_RPC_URL}`
       )
 
       const blockNumber = tokenData.mintInfo.mintContext.blockNumber
+      const auctionDuration = auctionState.endTime - auctionState.startTime
 
       provider.getBlock(blockNumber).then((block) => {
-        setTimestamp(block.timestamp)
+        setTimestamp(block.timestamp + auctionDuration)
       })
     }
     return
-  }, [tokenData])
+  }, [tokenData, auctionState])
 
   const externalLinkBaseURI = 'https://nouns.build/dao'
 

--- a/constants/rpcEndpoint.ts
+++ b/constants/rpcEndpoint.ts
@@ -1,0 +1,6 @@
+import { ENV } from 'utils/env'
+
+export const ALCHEMY_RPC_URL = {
+  1: `https://eth-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_KEY}`,
+  5: `https://eth-goerli.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_KEY}`,
+}[ENV.CHAIN]


### PR DESCRIPTION
closes #187 

updated to pull blocknumber from tokenData and get correct timestamp via ethers provider side function.

before:
![image](https://github.com/public-assembly/flexible/assets/65736142/53253173-ad43-4aa0-89a1-26ae430e4452)


after:
![image](https://github.com/public-assembly/flexible/assets/65736142/b9394a0e-6f7c-4388-b0d0-bf8c75287925)
