### PR TITLE
fix: prevent focus on hide button on auction sheet open

### DIFF
--- a/components/base/Sheet.tsx
+++ b/components/base/Sheet.tsx
@@ -183,6 +183,7 @@ const SheetContent = React.forwardRef<
   <SheetPortal position={position} forceMount>
     <SheetOverlay />
     <SheetPrimitive.Content
+      onOpenAutoFocus={(event) => event.preventDefault()}
       ref={ref}
       className={cn(sheetVariants({ position, size }), className)}
       {...props}
@@ -251,10 +252,10 @@ SheetDescription.displayName = SheetPrimitive.Description.displayName
 
 export {
   Sheet,
-  SheetTrigger,
   SheetContent,
-  SheetHeader,
-  SheetFooter,
-  SheetTitle,
   SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
 }


### PR DESCRIPTION
closes #144

Radix has autofocus for the dialog.content, not entirely sure if this 'dialog.close' specific for some kind of ARIA standard or just automatic to the first interactive child (could still be ARIA standard, might be worth understanding why), but simple event.preventDefault seems to achieve desired behavior described in issue.